### PR TITLE
GitHub Actions: Do not use LFS for kustomize provider

### DIFF
--- a/.github/workflows/terraform.yaml
+++ b/.github/workflows/terraform.yaml
@@ -9,8 +9,11 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v2
-      with:
-        lfs: true
+
+    - name: Get Kustomize provider
+      run: |
+        wget -q https://github.com/kbst/terraform-provider-kustomize/releases/download/v0.1.2-beta.0/terraform-provider-kustomization-linux-amd64_v0.1.2-beta.0.tgz -O /tmp/kustomize.tgz
+        tar -xvzf /tmp/kustomize.tgz -C .
 
     - name: Setup Terraform
       uses: hashicorp/setup-terraform@v1


### PR DESCRIPTION
We only have 1GB of bandwidth for LFS